### PR TITLE
Adding keyboard support for sortable headers cells

### DIFF
--- a/src/react/plugins/column-sorting/index.ts
+++ b/src/react/plugins/column-sorting/index.ts
@@ -37,6 +37,15 @@ export const columnSorting =
 								onClick: () =>
 									dispatch({ type: "SORT_COLUMN_TOGGLE", id: props.column.id }),
 								"aria-sort": sortDirection,
+								tabindex: 0,
+								onKeyDown: (e: KeyboardEvent) => {
+									if (e.key === "Enter") {
+									  dispatch({
+										type: "SORT_COLUMN_TOGGLE",
+										id: props.column.id,
+									  });
+									}
+								  },
 							};
 						},
 					};


### PR DESCRIPTION
Keyboard support applied to sortable header cells, so that keyboard users can sort the table columns appropriately.